### PR TITLE
Add logging to testSettings modification functions

### DIFF
--- a/squape/settings.py
+++ b/squape/settings.py
@@ -7,6 +7,7 @@
 from contextlib import contextmanager
 
 import squish
+import test
 from squape.internal.exceptions import SquishCapabilityError
 
 
@@ -25,6 +26,9 @@ def _ctx_settings(setting_name, value):
     """
     try:
         current_value = getattr(squish.testSettings, setting_name)
+        test.log(
+            f"Setting value of '{setting_name}' setting from {current_value} to {value}"
+        )
         setattr(squish.testSettings, setting_name, value)
     except AttributeError:
         raise SquishCapabilityError(
@@ -36,6 +40,9 @@ def _ctx_settings(setting_name, value):
     except Exception:
         raise
     finally:
+        test.log(
+            f"Setting value of '{setting_name}' setting from {value} to {current_value}"
+        )
         setattr(squish.testSettings, setting_name, current_value)
 
 

--- a/squape/settings.py
+++ b/squape/settings.py
@@ -7,8 +7,8 @@
 from contextlib import contextmanager
 
 import squish
-import test
 from squape.internal.exceptions import SquishCapabilityError
+from squape.report import debug
 
 
 @contextmanager
@@ -26,7 +26,7 @@ def _ctx_settings(setting_name, value):
     """
     try:
         current_value = getattr(squish.testSettings, setting_name)
-        test.log(
+        debug(
             f"Setting value of '{setting_name}' setting from {current_value} to {value}"
         )
         setattr(squish.testSettings, setting_name, value)
@@ -40,7 +40,7 @@ def _ctx_settings(setting_name, value):
     except Exception:
         raise
     finally:
-        test.log(
+        debug(
             f"Setting value of '{setting_name}' setting from {value} to {current_value}"
         )
         setattr(squish.testSettings, setting_name, current_value)


### PR DESCRIPTION
Added logs allow observing the status of the temporarily modified setting from testSettings in the test results.

Solves: #11 