### PR TITLE
Fix setting initial LOGLEVEL to 'LOG'

### DIFF
--- a/squape/report.py
+++ b/squape/report.py
@@ -58,7 +58,7 @@ def set_level(level) -> None:
     LOGLEVEL = __translate_Level(level)
 
 
-LOGLEVEL = set_level(LogLevel.LOG)
+set_level(LogLevel.LOG)
 
 _test_log = test.log
 _test_warning = test.warning


### PR DESCRIPTION
The previous version set the initial LOGLEVEL to None