### PR TITLE
Adapt Examples sections to be multiline for mkdocs

### DIFF
--- a/squape/report.py
+++ b/squape/report.py
@@ -55,8 +55,8 @@ def set_level(level) -> None:
         level (int|str): log level to set
 
     Examples:
-       set_level(report.LogLevel.WARNING)
-       set_level("FAIL")
+       >>> set_level(report.LogLevel.WARNING)
+       >>> set_level("FAIL")
     """
     global LOGLEVEL
     LOGLEVEL = __translate_Level(level)
@@ -255,9 +255,9 @@ def section(title: str, description: str = "") -> None:
         title (str): Section title
         description (str): Optional additional description of the section
     Examples:
-        with section("Add new person"):
-            squish.type(squish.waitForObject(names.forename_edit), "Bob")
-            squish.mouseClick(squish.waitForObject(names.ok_button))
+        >>> with section("Add new person"):
+        >>>     squish.type(squish.waitForObject(names.forename_edit), "Bob")
+        >>>     squish.mouseClick(squish.waitForObject(names.ok_button))
     """
 
     test.fixateResultContext(1)

--- a/squape/report.py
+++ b/squape/report.py
@@ -6,9 +6,9 @@
 # LICENSE file in the root directory of this source tree.
 from contextlib import contextmanager
 
-try:  
-    import squish  
-except ImportError:  
+try:
+    import squish
+except ImportError:
     import squishtest as squish
 
 import test
@@ -94,8 +94,8 @@ def debug(msg: str, details: str = "") -> None:
     Otherwise, it will be ignored and not included in the test report.
 
     Args:
-    - msg (str): The message to include in the log entry.
-    - details (str): Optional additional details to include in the log entry.
+        msg (str): The message to include in the log entry.
+        details (str): Optional additional details to include in the log entry.
 
     Returns:
         None
@@ -119,8 +119,8 @@ def log(msg: str, details: str = "") -> None:
     Otherwise, it will be ignored and not included in the test report.
 
     Args:
-    - msg (str): The message to include in the log entry.
-    - details (str): Optional additional details to include in the log entry.
+        msg (str): The message to include in the log entry.
+        details (str): Optional additional details to include in the log entry.
 
     Returns:
         None
@@ -145,8 +145,8 @@ def warning(msg: str, details: str = "") -> None:
     Otherwise, it will be ignored and not included in the test report.
 
     Args:
-    - msg (str): The message to include in the warning entry.
-    - details (str): Optional additional details to include in the warning entry.
+        msg (str): The message to include in the warning entry.
+        details (str): Optional additional details to include in the warning entry.
 
     Returns:
         None
@@ -170,8 +170,8 @@ def fail(msg: str, details: str = "") -> None:
     Otherwise, it will be ignored and not included in the test report.
 
     Args:
-    - msg (str): The message to include in the fail entry.
-    - details (str): Optional additional details to include in the fail entry.
+        msg (str): The message to include in the fail entry.
+        details (str): Optional additional details to include in the fail entry.
 
     Returns:
         None
@@ -198,8 +198,8 @@ def fatal(msg: str, details: str = "") -> None:
     After adding the fatal message, the function aborts the test case execution.
 
     Args:
-    - msg (str): The message to include in the fatal entry.
-    - details (str): Optional additional details to include in the fatal entry.
+        msg (str): The message to include in the fatal entry.
+        details (str): Optional additional details to include in the fatal entry.
 
     Returns:
         None
@@ -213,7 +213,7 @@ def fatal(msg: str, details: str = "") -> None:
             test.restoreResultContext()
 
 
-def enable_loglevel_in_test_module():
+def enable_loglevel_in_test_module() -> None:
     """Adds support for log levels to the Squish 'test' module.
 
     DISCLAIMER: This function uses monkeypathching
@@ -255,9 +255,11 @@ def section(title: str, description: str = "") -> None:
         title (str): Section title
         description (str): Optional additional description of the section
     Examples:
-        >>> with section("Add new person"):
-        >>>     squish.type(squish.waitForObject(names.forename_edit), "Bob")
-        >>>     squish.mouseClick(squish.waitForObject(names.ok_button))
+        ```python
+        with section("Add new person"):
+            squish.type(squish.waitForObject(names.forename_edit), "Bob")
+            squish.mouseClick(squish.waitForObject(names.ok_button))
+        ```
     """
 
     test.fixateResultContext(1)

--- a/squape/settings.py
+++ b/squape/settings.py
@@ -6,9 +6,9 @@
 # LICENSE file in the root directory of this source tree.
 from contextlib import contextmanager
 
-try:  
-    import squish  
-except ImportError:  
+try:
+    import squish
+except ImportError:
     import squishtest as squish
 
 from squape.internal.exceptions import SquishCapabilityError
@@ -60,8 +60,10 @@ def logScreenshotOnPass(enabled: bool = True) -> None:
         of screenshots on PASS test result. Defaulting to True.
 
     Examples:
-        >>> with logScreenshotOnPass():
-        >>>     # code with verifications
+        ```python
+        with logScreenshotOnPass():
+            # code with verifications
+        ```
     """
     with _ctx_settings("logScreenshotOnPass", enabled):
         yield
@@ -77,8 +79,10 @@ def logScreenshotOnFail(enabled: bool = True) -> None:
         of screenshots on FAIL test result. Defaulting to True.
 
     Examples:
-        >>> with logScreenshotOnFail():
-        >>>     # code with verifications
+        ```python
+        with logScreenshotOnFail():
+            # code with verifications
+        ```
     """
 
     with _ctx_settings("logScreenshotOnFail", enabled):
@@ -90,13 +94,15 @@ def logScreenshotOnWarning(enabled: bool = True) -> None:
     """Allows using logScreenshotOnWarning test setting as context managers.
     https://doc.qt.io/squish/squish-api.html#bool-testsettings-logscreenshotonwarning
 
-     Args:
+    Args:
         enabled (bool): A boolean value indicating whether to enable logging
         of screenshots on warning log entry. Defaulting to True.
 
     Examples:
-        >>> with logScreenshotOnWarning():
-        >>>     # code where warning messages might happen
+        ```python
+        with logScreenshotOnWarning():
+            # code where warning messages might happen
+        ```
     """
     with _ctx_settings("logScreenshotOnWarning", enabled):
         yield
@@ -111,8 +117,10 @@ def silentVerifications(enabled: bool = True) -> None:
         enabled (bool): Whether silent verifications are enabled. Defaulting to True
 
     Examples:
-        >>> with silentVerifications():
-        >>>     # code with test.vp statements
+        ```python
+        with silentVerifications():
+            # code with test.vp statements
+        ```
     """
     with _ctx_settings("silentVerifications", enabled):
         yield
@@ -128,9 +136,10 @@ def imageSearchTolerant(enabled: bool = True) -> None:
         Defaulting to True.
 
     Examples:
-        >>> with imageSearchTolerant(), imageSearchThreshold(95):
-        >>>     test.imagePresent()
-
+        ```python
+        with imageSearchTolerant(), imageSearchThreshold(95):
+            test.imagePresent()
+        ```
     """
     with _ctx_settings("imageSearchTolerant", enabled):
         yield
@@ -145,8 +154,10 @@ def imageSearchThreshold(threshold: float) -> None:
         threshold (float): the threshold for image search.
 
     Examples:
-        >>> with imageSearchTolerant(), imageSearchThreshold(95):
-        >>>     test.imagePresent("image.png")
+        ```python
+        with imageSearchTolerant(), imageSearchThreshold(95):
+            test.imagePresent("image.png")
+        ```
     """
     with _ctx_settings("imageSearchThreshold", threshold):
         yield
@@ -161,10 +172,11 @@ def imageSearchMultiscale(enabled: bool = True) -> None:
         enabled (bool): Whether multi-scale image search is enabled. Defaulting to True
 
     Examples:
-        >>> with imageSearchMultiscale(), imageSearchMaxScale(150):
-        >>>     test.imagePresent("image1.png")
-        >>>     test.imagePresent("image2.png")
-
+        ```python
+        with imageSearchMultiscale(), imageSearchMaxScale(150):
+            test.imagePresent("image1.png")
+            test.imagePresent("image2.png")
+        ```
     """
     with _ctx_settings("imageSearchMultiscale", enabled):
         yield
@@ -179,9 +191,11 @@ def imageSearchMinScale(min_scale: float) -> None:
         min_scale (float): A float value indicating the minimum scale for image search.
 
     Examples:
-        >>> with imageSearchMultiscale(), imageSearchMinScale(75):
-        >>>     test.imagePresent("image1.png")
-        >>>     test.imagePresent("image2.png")
+        ```python
+        with imageSearchMultiscale(), imageSearchMinScale(75):
+            test.imagePresent("image1.png")
+            test.imagePresent("image2.png")
+        ```
     """
     with _ctx_settings("imageSearchMinScale", min_scale):
         yield
@@ -196,9 +210,11 @@ def imageSearchMaxScale(max_scale: float) -> None:
         max_scale (float): A float value indicating the maximum scale for image search.
 
     Examples:
-        >>> with imageSearchMultiscale(), imageSearchMaxScale(150):
-        >>>     test.imagePresent("image1.png")
-        >>>     test.imagePresent("image2.png")
+        ```python
+        with imageSearchMultiscale(), imageSearchMaxScale(150):
+            test.imagePresent("image1.png")
+            test.imagePresent("image2.png")
+        ```
     """
     with _ctx_settings("imageSearchMaxScale", max_scale):
         yield
@@ -213,9 +229,11 @@ def waitForObjectTimeout(timeout_ms: int) -> None:
         timeout_ms (int): A integer value indicating the timeout in ms.
 
     Examples:
-        >>> with waitForObjectTimeout(500):
-        >>>     waitForObject(names.obj1)
-        >>>     waitForObject(names.obj2)
+        ```python
+        with waitForObjectTimeout(500):
+            waitForObject(names.obj1)
+            waitForObject(names.obj2)
+        ```
     """
     with _ctx_settings("waitForObjectTimeout", timeout_ms):
         yield
@@ -230,9 +248,11 @@ def objectNotFoundDebugging(enabled: bool) -> None:
         enabled (bool): Whether to enable debugging when object is not found.
 
     Examples:
-        >>> with objectNotFoundDebugging(False):
-        >>>     waitForObject(names.obj1)
-        >>>     waitForObject(names.obj2)
+        ```python
+        with objectNotFoundDebugging(False):
+            waitForObject(names.obj1)
+            waitForObject(names.obj2)
+        ```
     """
     with _ctx_settings("objectNotFoundDebugging", enabled):
         yield
@@ -247,9 +267,11 @@ def imageNotFoundDebugging(enabled: bool) -> None:
         enabled (bool): Whether to enable debugging when image is not found.
 
     Examples:
-        >>> with imageNotFoundDebugging(False):
-        >>>     waitForImage("image1.png")
-        >>>     waitForImage("image2.png")
+        ```python
+        with imageNotFoundDebugging(False):
+            waitForImage("image1.png")
+            waitForImage("image2.png")
+        ```
     """
     with _ctx_settings("imageNotFoundDebugging", enabled):
         yield
@@ -264,9 +286,11 @@ def textNotFoundDebugging(enabled: bool) -> None:
         enabled (bool): Whether to enable debugging when a OCR Text is not found.
 
     Examples:
-        >>> with textNotFoundDebugging(False):
-        >>>     waitForOcrText("Frog")
-        >>>     waitForOcrText("Alpaca")
+        ```python
+        with textNotFoundDebugging(False):
+            waitForOcrText("Frog")
+            waitForOcrText("Alpaca")
+        ```
     """
     with _ctx_settings("textNotFoundDebugging", enabled):
         yield
@@ -282,9 +306,11 @@ def defaultOcrLanguage(language: str) -> None:
         for OCR Text search
 
     Examples:
-        >>> with defaultOcrLanguage("Polish"):
-        >>>     waitForOcrText("Dom")
-        >>>     waitForOcrText("Miasto")
+        ```python
+        with defaultOcrLanguage("Polish"):
+            waitForOcrText("Dom")
+            waitForOcrText("Miasto")
+        ```
     """
     with _ctx_settings("defaultOcrLanguage", language):
         yield
@@ -300,8 +326,10 @@ def breakOnFailure(enabled: bool = True) -> None:
         on every failed verification
 
     Examples:
-        >>> with breakOnFailure():
-        >>>     # code with verifications
+        ```python
+        with breakOnFailure():
+            # code with verifications
+        ```
     """
     with _ctx_settings("breakOnFailure", enabled):
         yield
@@ -317,9 +345,10 @@ def throwOnFailure(enabled: bool) -> None:
         on every failed verification
 
     Examples:
-        >>> with throwOnFailure():
-        >>>     # code with verifications
-
+        ```python
+        with throwOnFailure():
+            # code with verifications
+        ```
     """
     with _ctx_settings("throwOnFailure", enabled):
         yield
@@ -335,9 +364,10 @@ def retryDuration(duration_ms: int) -> None:
         the verification fails
 
     Examples:
-        >>> with retryDuration(5000):
-        >>>     test.vp("VP1")
-
+        ```python
+        with retryDuration(5000):
+            test.vp("VP1")
+        ```
     """
     with _ctx_settings("retryDuration", duration_ms):
         yield

--- a/squape/settings.py
+++ b/squape/settings.py
@@ -59,9 +59,9 @@ def logScreenshotOnPass(enabled: bool = True) -> None:
         enabled (bool): A boolean value indicating whether to enable logging
         of screenshots on PASS test result. Defaulting to True.
 
-    Example:
-        with logScreenshotOnPass():
-            # code with verifications
+    Examples:
+        >>> with logScreenshotOnPass():
+        >>>     # code with verifications
     """
     with _ctx_settings("logScreenshotOnPass", enabled):
         yield
@@ -76,9 +76,9 @@ def logScreenshotOnFail(enabled: bool = True) -> None:
         enabled (bool): A boolean value indicating whether to enable logging
         of screenshots on FAIL test result. Defaulting to True.
 
-    Example:
-        with logScreenshotOnFail():
-            # code with verifications
+    Examples:
+        >>> with logScreenshotOnFail():
+        >>>     # code with verifications
     """
 
     with _ctx_settings("logScreenshotOnFail", enabled):
@@ -94,9 +94,9 @@ def logScreenshotOnWarning(enabled: bool = True) -> None:
         enabled (bool): A boolean value indicating whether to enable logging
         of screenshots on warning log entry. Defaulting to True.
 
-    Example:
-        with logScreenshotOnWarning():
-            # code where warning messages might happen
+    Examples:
+        >>> with logScreenshotOnWarning():
+        >>>     # code where warning messages might happen
     """
     with _ctx_settings("logScreenshotOnWarning", enabled):
         yield
@@ -110,9 +110,9 @@ def silentVerifications(enabled: bool = True) -> None:
     Args:
         enabled (bool): Whether silent verifications are enabled. Defaulting to True
 
-    Example:
-        with silentVerifications():
-            # code with test.vp statements
+    Examples:
+        >>> with silentVerifications():
+        >>>     # code with test.vp statements
     """
     with _ctx_settings("silentVerifications", enabled):
         yield
@@ -127,9 +127,9 @@ def imageSearchTolerant(enabled: bool = True) -> None:
         enabled (bool): Whether image search with tolerance is enabled.
         Defaulting to True.
 
-    Example:
-        with imageSearchTolerant(), imageSearchThreshold(95):
-            test.imagePresent()
+    Examples:
+        >>> with imageSearchTolerant(), imageSearchThreshold(95):
+        >>>     test.imagePresent()
 
     """
     with _ctx_settings("imageSearchTolerant", enabled):
@@ -144,9 +144,9 @@ def imageSearchThreshold(threshold: float) -> None:
     Args:
         threshold (float): the threshold for image search.
 
-    Example:
-        with imageSearchTolerant(), imageSearchThreshold(95):
-            test.imagePresent("image.png")
+    Examples:
+        >>> with imageSearchTolerant(), imageSearchThreshold(95):
+        >>>     test.imagePresent("image.png")
     """
     with _ctx_settings("imageSearchThreshold", threshold):
         yield
@@ -160,10 +160,10 @@ def imageSearchMultiscale(enabled: bool = True) -> None:
     Args:
         enabled (bool): Whether multi-scale image search is enabled. Defaulting to True
 
-    Example:
-        with imageSearchMultiscale(), imageSearchMaxScale(150):
-            test.imagePresent("image1.png")
-            test.imagePresent("image2.png")
+    Examples:
+        >>> with imageSearchMultiscale(), imageSearchMaxScale(150):
+        >>>     test.imagePresent("image1.png")
+        >>>     test.imagePresent("image2.png")
 
     """
     with _ctx_settings("imageSearchMultiscale", enabled):
@@ -178,10 +178,10 @@ def imageSearchMinScale(min_scale: float) -> None:
     Args:
         min_scale (float): A float value indicating the minimum scale for image search.
 
-    Example:
-        with imageSearchMultiscale(), imageSearchMinScale(75):
-            test.imagePresent("image1.png")
-            test.imagePresent("image2.png")
+    Examples:
+        >>> with imageSearchMultiscale(), imageSearchMinScale(75):
+        >>>     test.imagePresent("image1.png")
+        >>>     test.imagePresent("image2.png")
     """
     with _ctx_settings("imageSearchMinScale", min_scale):
         yield
@@ -195,10 +195,10 @@ def imageSearchMaxScale(max_scale: float) -> None:
     Args:
         max_scale (float): A float value indicating the maximum scale for image search.
 
-    Example:
-        with imageSearchMultiscale(), imageSearchMaxScale(150):
-            test.imagePresent("image1.png")
-            test.imagePresent("image2.png")
+    Examples:
+        >>> with imageSearchMultiscale(), imageSearchMaxScale(150):
+        >>>     test.imagePresent("image1.png")
+        >>>     test.imagePresent("image2.png")
     """
     with _ctx_settings("imageSearchMaxScale", max_scale):
         yield
@@ -212,10 +212,10 @@ def waitForObjectTimeout(timeout_ms: int) -> None:
     Args:
         timeout_ms (int): A integer value indicating the timeout in ms.
 
-    Example:
-        with waitForObjectTimeout(500):
-            waitForObject(names.obj1)
-            waitForObject(names.obj2)
+    Examples:
+        >>> with waitForObjectTimeout(500):
+        >>>     waitForObject(names.obj1)
+        >>>     waitForObject(names.obj2)
     """
     with _ctx_settings("waitForObjectTimeout", timeout_ms):
         yield
@@ -229,10 +229,10 @@ def objectNotFoundDebugging(enabled: bool) -> None:
     Args:
         enabled (bool): Whether to enable debugging when object is not found.
 
-    Example:
-        with objectNotFoundDebugging(False):
-            waitForObject(names.obj1)
-            waitForObject(names.obj2)
+    Examples:
+        >>> with objectNotFoundDebugging(False):
+        >>>     waitForObject(names.obj1)
+        >>>     waitForObject(names.obj2)
     """
     with _ctx_settings("objectNotFoundDebugging", enabled):
         yield
@@ -246,10 +246,10 @@ def imageNotFoundDebugging(enabled: bool) -> None:
      Args:
         enabled (bool): Whether to enable debugging when image is not found.
 
-    Example:
-        with imageNotFoundDebugging(False):
-            waitForImage("image1.png")
-            waitForImage("image2.png")
+    Examples:
+        >>> with imageNotFoundDebugging(False):
+        >>>     waitForImage("image1.png")
+        >>>     waitForImage("image2.png")
     """
     with _ctx_settings("imageNotFoundDebugging", enabled):
         yield
@@ -263,10 +263,10 @@ def textNotFoundDebugging(enabled: bool) -> None:
     Args:
         enabled (bool): Whether to enable debugging when a OCR Text is not found.
 
-    Example:
-        with textNotFoundDebugging(False):
-            waitForOcrText("Frog")
-            waitForOcrText("Alpaca")
+    Examples:
+        >>> with textNotFoundDebugging(False):
+        >>>     waitForOcrText("Frog")
+        >>>     waitForOcrText("Alpaca")
     """
     with _ctx_settings("textNotFoundDebugging", enabled):
         yield
@@ -281,10 +281,10 @@ def defaultOcrLanguage(language: str) -> None:
         language (str): string text representing the Language to be used
         for OCR Text search
 
-    Example:
-        with defaultOcrLanguage("Polish"):
-            waitForOcrText("Dom")
-            waitForOcrText("Miasto")
+    Examples:
+        >>> with defaultOcrLanguage("Polish"):
+        >>>     waitForOcrText("Dom")
+        >>>     waitForOcrText("Miasto")
     """
     with _ctx_settings("defaultOcrLanguage", language):
         yield
@@ -299,9 +299,9 @@ def breakOnFailure(enabled: bool = True) -> None:
         enabled (bool): Whether to enable the debugger to stop
         on every failed verification
 
-    Example:
-        with breakOnFailure():
-            # code with verifications
+    Examples:
+        >>> with breakOnFailure():
+        >>>     # code with verifications
     """
     with _ctx_settings("breakOnFailure", enabled):
         yield
@@ -316,9 +316,9 @@ def throwOnFailure(enabled: bool) -> None:
         enabled (bool): Whether to enable to raise a script error
         on every failed verification
 
-    Example:
-    with throwOnFailure():
-        # code with verifications
+    Examples:
+        >>> with throwOnFailure():
+        >>>     # code with verifications
 
     """
     with _ctx_settings("throwOnFailure", enabled):
@@ -334,9 +334,9 @@ def retryDuration(duration_ms: int) -> None:
         duration_ms (int): The duration in milliseconds after which
         the verification fails
 
-    Example:
-        with retryDuration(5000):
-            test.vp("VP1")
+    Examples:
+        >>> with retryDuration(5000):
+        >>>     test.vp("VP1")
 
     """
     with _ctx_settings("retryDuration", duration_ms):

--- a/squape/squishserver.py
+++ b/squape/squishserver.py
@@ -178,7 +178,7 @@ class SquishServer:
         Args:
             aut (str): the name of the attachable AUT
         Returns:
-            ctx : Application Context
+            (ApplicationContext): application context
         """
         log(f"[Squishserver {self.host}:{self.port}] " f"Attach to application {aut}")
         ctx = squish.attachToApplication(aut, self.host, self.port)
@@ -191,7 +191,7 @@ class SquishServer:
         Args:
             aut (str): the name of the mapped AUT
         Returns:
-            ctx : Application Context
+            (ApplicationContext): application context
         """
         log(f"[Squishserver {self.host}:{self.port}] " f"Start an application {aut}")
         ctx = squish.startApplication(aut, self.host, self.port)

--- a/squape/squishserver.py
+++ b/squape/squishserver.py
@@ -2,13 +2,15 @@
 import os
 from pathlib import Path
 
-try:  
-    import squish  
-except ImportError:  
+try:
+    import squish
+except ImportError:
     import squishtest as squish
+from remotesystem import RemoteSystem
 
-from squape.internal.exceptions import EnvironmentError, SquishserverError
-from squape.report import debug, log
+from internal.exceptions import EnvironmentError
+from internal.exceptions import SquishserverError
+from report import debug, log
 
 
 class SquishServer:

--- a/squape/video.py
+++ b/squape/video.py
@@ -20,7 +20,7 @@ def _failure_results_count() -> int:
     all the counts for errors, fatals, xpasses and fails.
 
     Returns:
-        int: The total number of failures in test results.
+        The total number of failures in test results.
     """
     return (
         test.resultCount("errors")
@@ -36,7 +36,7 @@ def _videos_set() -> set:
     RESULT_DIR/TEST_SUITE_NAME/TEST_CASE_NAME/attachments.
 
     Returns:
-        set: The set of filenames with mp4 extension
+        The set of filenames with mp4 extension
     """
     video_dir = os.path.join(
         squishinfo.resultDir,
@@ -99,9 +99,10 @@ def video_capture(message: str = "", remove_on_success: bool = False) -> None:
         when there were no failures. Defaulting to False.
 
     Examples:
-        >>> with video_capture(remove_on_success=True):
-        >>>     # code with actions and verifications
-
+        ```python
+        with video_capture(remove_on_success=True):
+            # code with actions and verifications
+        ```
     """
 
     if remove_on_success:

--- a/squape/video.py
+++ b/squape/video.py
@@ -98,9 +98,9 @@ def video_capture(message: str = "", remove_on_success: bool = False) -> None:
         remove_on_success (bool): Whether to replace captured video
         when there were no failures. Defaulting to False.
 
-    Example:
-        with video_capture(remove_on_success=True):
-            # code with actions and verifications
+    Examples:
+        >>> with video_capture(remove_on_success=True):
+        >>>     # code with actions and verifications
 
     """
 

--- a/squape/vps.py
+++ b/squape/vps.py
@@ -7,9 +7,9 @@
 import operator
 import time
 
-try:  
-    import squish  
-except ImportError:  
+try:
+    import squish
+except ImportError:
     import squishtest as squish
 
 import test
@@ -28,7 +28,7 @@ def vph_property(
         expected_value (any): expected value of the verified property
         msg (str): verification message
     Returns:
-        bool: True if verification is positive, False otherwise
+        True if verification is positive, False otherwise
     """
 
     obj = squish.waitForObjectExists(object_name)


### PR DESCRIPTION
Changes:
- Rename Example to Examples for all Example sections. This is required for mkdocs to display multi-line examples correctly.
- Add the >>> to each line in the Examples. It forces mkdocs to not squash examples into one line.