### PR TITLE
Add warning in function doc about removing videos not working in Squish 7.1.1 and below

### DIFF
--- a/squape/video.py
+++ b/squape/video.py
@@ -92,6 +92,9 @@ def video_capture(message: str = "", remove_on_success: bool = False) -> None:
     Optionally (when the execution was successful) replace captured video
     with a tiny placeholder video to save test results size.
 
+    Warning: Removing videos on success does not work with Squish 7.1.1 and below 
+    when execution is triggered outside the Squish IDE. 
+
     Args:
         message (str): log a video n the test report using the specified message.
         Defaulting to empty string.
@@ -127,6 +130,9 @@ def video_capture(message: str = "", remove_on_success: bool = False) -> None:
 def remove_videos_on_success() -> None:
     """
     Remove all captured videos when the execution was successful (no failures)
+
+    Warning: Removing videos on success does not work with Squish 7.1.1 and below 
+    when execution is triggered outside the Squish IDE. 
     """
     if _failure_results_count() == 0:
         videos_to_remove = _videos_set()

--- a/squape/video.py
+++ b/squape/video.py
@@ -92,9 +92,9 @@ def video_capture(message: str = "", remove_on_success: bool = False) -> None:
     Optionally (when the execution was successful) replace captured video
     with a tiny placeholder video to save test results size.
 
-    Warning: Removing videos on success does not work with Squish 7.1.1 and below 
-    when execution is triggered outside the Squish IDE. 
-
+    !!! warning
+        Removing videos on success does not work with Squish 7.1.1 and below 
+        when execution is triggered outside the Squish IDE. 
     Args:
         message (str): log a video n the test report using the specified message.
         Defaulting to empty string.

--- a/squape/video.py
+++ b/squape/video.py
@@ -131,8 +131,9 @@ def remove_videos_on_success() -> None:
     """
     Remove all captured videos when the execution was successful (no failures)
 
-    Warning: Removing videos on success does not work with Squish 7.1.1 and below 
-    when execution is triggered outside the Squish IDE. 
+    !!! warning
+        Removing videos on success does not work with Squish 7.1.1 and below 
+        when execution is triggered outside the Squish IDE. 
     """
     if _failure_results_count() == 0:
         videos_to_remove = _videos_set()


### PR DESCRIPTION
When tests are run outside IDE removing videos on success does not work. This needs to be documented.