### PR TITLE
Add path conversion for addAUT()

### DIFF
--- a/squape/squishserver.py
+++ b/squape/squishserver.py
@@ -108,11 +108,12 @@ class SquishServer:
             aut (str): the name of the executable
             path (str): path to the executable folder
         """
+        path_resolved = Path(path).as_posix()
         log(
             f"[Squishserver {self.host}:{self.port}] "
-            f"Registering {Path(path)/aut} AUT"
+            f"Registering {path_resolved/aut} AUT"
         )
-        self._config_squishserver("addAUT", [aut, path])
+        self._config_squishserver("addAUT", [aut, path_resolved])
 
     def removeAUT(self, aut: str, path: str) -> None:
         """Remove registered AUT


### PR DESCRIPTION
This adds the automatic conversion for provided paths to the Squish server integration (addAUT, addAUTPath, removeAUT, etc) to POSIX style (only forward slashes).

The intention of that is to fix problems with registering AUTs on remote systems, without knowing the platform.