### PR TITLE
Add wait_for_any_object functionality to object_tree module

### DIFF
--- a/squape/object_tree.py
+++ b/squape/object_tree.py
@@ -278,7 +278,6 @@ def _get_object_reference(object_or_name: any) -> any:
 def _wait_for_any_object(
     lookup_function, object_names: list, timeout: int, retry_delay: float
 ):
-    lookup_errors = set()
     start_time = time.time()
 
     while time.time() - start_time < timeout:
@@ -288,11 +287,10 @@ def _wait_for_any_object(
 
             except LookupError as e:
                 debug(f"{e}")
-                lookup_errors.add(str(e))
 
         squish.snooze(retry_delay)
 
-    raise LookupError(f"Objects not found: {lookup_errors}")
+    raise LookupError(f"Objects {object_names} not found")
 
 
 def wait_for_any_object(

--- a/squape/object_tree.py
+++ b/squape/object_tree.py
@@ -14,8 +14,7 @@ except ImportError:
     import squishtest as squish
 
 import object
-from settings import objectNotFoundDebugging
-
+from squape.settings import objectNotFoundDebugging
 
 def children(object_or_name: any, selector: dict) -> tuple:
     """

--- a/squape/object_tree.py
+++ b/squape/object_tree.py
@@ -278,8 +278,9 @@ def _wait_for_any_object(
 ):
     lookup_errors = set()
     start_time = time.time()
-
-    while True:
+    elapsed_time = 0
+    
+    while elapsed_time < timeout:
         for obj_name in object_names:
             try:
                 return lookup_function(obj_name, 0)
@@ -288,9 +289,6 @@ def _wait_for_any_object(
                 lookup_errors.add(str(e))
 
         elapsed_time = time.time() - start_time
-        if elapsed_time > timeout:
-            break
-
         squish.snooze(retry_delay)
 
     raise LookupError(f"Objects not found: {lookup_errors}")

--- a/squape/object_tree.py
+++ b/squape/object_tree.py
@@ -278,6 +278,9 @@ def _get_object_reference(object_or_name: any) -> any:
 def _wait_for_any_object(
     lookup_function, object_names: list, timeout: int, retry_delay: float
 ):
+    if not object_names:
+        raise ValueError("Object names list is empty!")
+
     start_time = time.time()
 
     while time.time() - start_time < timeout:
@@ -316,6 +319,7 @@ def wait_for_any_object(
     Raises:
         LookupError: If none of the objects become available within
             the specified timeout.
+        ValueError: If object_names list is empty
     """
     return _wait_for_any_object(
         squish.waitForObject, object_names, timeout, retry_delay=retry_delay
@@ -345,6 +349,7 @@ def wait_for_any_object_exists(
     Raises:
         LookupError: If none of the objects become available within
             the specified timeout.
+        ValueError: If object_names list is empty
     """
     return _wait_for_any_object(
         squish.waitForObjectExists, object_names, timeout, retry_delay=retry_delay

--- a/squape/object_tree.py
+++ b/squape/object_tree.py
@@ -15,6 +15,8 @@ except ImportError:
 
 import object
 from squape.settings import objectNotFoundDebugging
+from squape.report import debug
+
 
 def children(object_or_name: any, selector: dict) -> tuple:
     """
@@ -279,13 +281,14 @@ def _wait_for_any_object(
     lookup_errors = set()
     start_time = time.time()
     elapsed_time = 0
-    
+
     while elapsed_time < timeout:
         for obj_name in object_names:
             try:
                 return lookup_function(obj_name, 0)
 
             except LookupError as e:
+                debug(f"{e}")
                 lookup_errors.add(str(e))
 
         elapsed_time = time.time() - start_time

--- a/squape/object_tree.py
+++ b/squape/object_tree.py
@@ -280,9 +280,8 @@ def _wait_for_any_object(
 ):
     lookup_errors = set()
     start_time = time.time()
-    elapsed_time = 0
 
-    while elapsed_time < timeout:
+    while time.time() - start_time < timeout:
         for obj_name in object_names:
             try:
                 return lookup_function(obj_name, 0)
@@ -291,7 +290,6 @@ def _wait_for_any_object(
                 debug(f"{e}")
                 lookup_errors.add(str(e))
 
-        elapsed_time = time.time() - start_time
         squish.snooze(retry_delay)
 
     raise LookupError(f"Objects not found: {lookup_errors}")


### PR DESCRIPTION
I created this PR to have a place to discuss two new functions:

```
def wait_for_any_object(
    object_names: list,
    timeout=squish.testSettings.waitForObjectTimeout / 1000,
    retry_delay: float = 0.5,
)

def wait_for_any_object_exists(
    object_names: list,
    timeout=squish.testSettings.waitForObjectTimeout / 1000,
    retry_delay: float = 0.5,
)
```